### PR TITLE
Datadog: Add priorityClassName and useDockerSocket chart options

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.3.1
+version: 1.3.3
 appVersion: 6.4.2
 description: DataDog Agent
 keywords:

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.3.0
+version: 1.3.1
 appVersion: 6.4.2
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -57,6 +57,7 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `datadog.tags`              | Set host tags                      | `nil`                                     |
 | `datadog.volumes`           | Additional volumes for the daemonset or deployment | `nil`                     |
 | `datadog.volumeMounts`      | Additional volumeMounts for the daemonset or deployment | `nil`                |
+| `datadog.useDockerSocketVolume` | Enable mounting the docker socket in Agent containers | `True`                |
 | `datadog.resources.requests.cpu` | CPU resource requests              | `200m`                                    |
 | `datadog.resources.limits.cpu` | CPU resource limits                | `200m`                                    |
 | `datadog.resources.requests.memory` | Memory resource requests           | `256Mi`                                   |

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -68,11 +68,13 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `daemonset.useHostNetwork`  | If true, use the host's network    | `nil`                                     |
 | `daemonset.useHostPID`.     | If true, use the host's PID namespace    | `nil`                               |
 | `daemonset.useHostPort`     | If true, use the same ports for both host and container  | `nil`               |
+| `daemonset.priorityClassName` | Which Priority Class to associate with the daemonset| `nil`                  |
 | `datadog.leaderElection`    | Enable the leader Election feature | `false`                                   |
 | `datadog.leaderLeaseDuration`| The duration for which a leader stays elected.| `nil`                         |
 | `datadog.collectEvents`     | Enable Kubernetes event collection. Requires leader election. | `false`        |
 | `deployment.affinity`       | Node / Pod affinities              | `{}`                                      |
 | `deployment.tolerations`    | List of node taints to tolerate    | `[]`                                      |
+| `deployment.priorityClassName` | Which Priority Class to associate with the deployment | `nil`               |
 | `kubeStateMetrics.enabled`  | If true, create kube-state-metrics | `true`                                    |
 | `kube-state-metrics.rbac.create`| If true, create & use RBAC resources for kube-state-metrics | `true`       |
 | `kube-state-metrics.rbac.serviceAccount` | existing ServiceAccount to use (ignored if rbac.create=true) for kube-state-metrics | `default` |

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -34,6 +34,9 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.daemonset.priorityClassName }}
+      priorityClassName: {{ .Values.daemonset.priorityClassName }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -116,9 +116,11 @@ spec:
 {{ toYaml .Values.datadog.env | indent 10 }}
 {{- end }}
         volumeMounts:
+          {{- if .Values.datadog.useDockerSocketVolume }}
           - name: dockersocket
             mountPath: /var/run/docker.sock
             readOnly: true
+          {{- end }}
           - name: procdir
             mountPath: /host/proc
             readOnly: true
@@ -154,9 +156,11 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 5
       volumes:
+        {{- if .Values.datadog.useDockerSocketVolume }}
         - hostPath:
             path: /var/run/docker.sock
           name: dockersocket
+        {{- end }}
         - hostPath:
             path: /proc
           name: procdir

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -76,9 +76,11 @@ spec:
 {{ toYaml .Values.datadog.env | indent 10 }}
 {{- end }}
         volumeMounts:
+          {{- if .Values.datadog.useDockerSocketVolume }}
           - name: dockersocket
             mountPath: /var/run/docker.sock
             readOnly: true
+          {{- end }}
           - name: procdir
             mountPath: /host/proc
             readOnly: true
@@ -105,9 +107,11 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 5
       volumes:
+        {{- if .Values.datadog.useDockerSocketVolume }}
         - hostPath:
             path: /var/run/docker.sock
           name: dockersocket
+        {{- end }}
         - hostPath:
             path: /proc
           name: procdir

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -26,6 +26,9 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.deployment.priorityClassName }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -115,6 +115,9 @@ datadog:
   ##
   # nonLocalTraffic: true
 
+  ## Enable docker socket volume mounting
+  useDockerSocketVolume: True
+
   ## Set host tags.
   ## ref: https://github.com/DataDog/docker-dd-agent#environment-variables
   ##

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -55,6 +55,9 @@ daemonset:
   ## ref: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
   # updateStrategy: RollingUpdate
 
+  ## Sets PriorityClassName if defined
+  # priorityClassName:
+
 # Apart from DaemonSet, deploy Datadog agent pods and related service for
 # applications that want to send custom metrics. Provides DogStasD service.
 #
@@ -72,6 +75,9 @@ deployment:
   # If you're using a NodePort-type service and need a fixed port, set this parameter.
   # dogstatsdNodePort: 8125
   # traceNodePort: 8126
+
+  ## Sets PriorityClassName if defined
+  # priorityClassName:
 
 ## deploy the kube-state-metrics deployment
 ## ref: https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics


### PR DESCRIPTION
- `priorityClassName` satisfies our requirement in https://github.com/quantopian/qexec/issues/15955
- `useDockerSocket` enables us to prevent binding the docker socket to our Agent containers